### PR TITLE
Bump microk8s version and adjust timeouts in testflinger automation

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -19,7 +19,7 @@ provision_data:
       # Juju 3.5 is supported until Jan 2025
       # https://juju.is/docs/juju/roadmap
       snap install juju --channel=3.5/stable
-      snap install microk8s --channel=1.30/stable
+      snap install microk8s --channel=1.30-strict/stable
       snap install --classic charmcraft
       snap refresh
 

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -19,7 +19,7 @@ provision_data:
       # Juju 3.5 is supported until Jan 2025
       # https://juju.is/docs/juju/roadmap
       snap install juju --channel=3.5/stable
-      snap install microk8s --channel=1.29-strict/stable
+      snap install microk8s --channel=1.30/stable
       snap install --classic charmcraft
       snap refresh
 
@@ -52,11 +52,15 @@ provision_data:
       microk8s.enable dns
       microk8s.kubectl rollout status \
         deployments/coredns \
-        -n kube-system -w --timeout=10800s
+        -n kube-system -w --timeout=1800s
+      # Give microk8s another minute to stabilize
+      # to avoid intermittent failures when
+      # enabling hostpath-storage
+      sleep 60
       microk8s.enable hostpath-storage
       microk8s.kubectl rollout status \
         deployments/hostpath-provisioner \
-        -n kube-system -w --timeout=10800s
+        -n kube-system -w --timeout=1800s
 
       # bootstrap microk8s controller and add model
       sudo -u ubuntu juju bootstrap microk8s microk8s

--- a/.github/testflinger/test-cmd-with-timeout.sh
+++ b/.github/testflinger/test-cmd-with-timeout.sh
@@ -13,7 +13,7 @@ if [ $# -eq 0 ]; then
 fi
 
 SLEEP_SECS=30
-TIMEOUT_SECS=10800
+TIMEOUT_SECS=1800
 elapsed_secs=0
 
 # capture all args passed to script and use as the test command


### PR DESCRIPTION
I'm seeing intermittent failures when enabling the `hostpath-storage` microk8s add-on. This attempts to address this issue by i) bumping the microk8s version to the latest stable release and ii) giving microk8s another minute to stabilize before enabling the add-on. I also reduced some timeouts that were set to very high values while I was troubleshooting last week.