### PR TITLE
Integration test improvements

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -1,4 +1,5 @@
 job_queue: dell-precision-3470-c30322
+output_timeout: 1800
 provision_data:
   distro: jammy
   user_data: |

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -1,74 +1,7 @@
-job_queue: dell-precision-3470-c30322
+job_queue: REPLACE_QUEUE
 output_timeout: 1800
 provision_data:
-  distro: jammy
-  user_data: |
-    #cloud-config
-    # Note, much of this is borrowed from the
-    # charm-dev multipass template:
-    # https://github.com/canonical/multipass-blueprints/blob/main/v1/charm-dev.yaml
-
-    runcmd:
-    - |
-      # Install apt and snap packages here instead
-      # of in "packages" and "snap" sections
-      # to ensure everything runs sequentially
-      DEBIAN_FRONTEND=noninteractive apt update
-      DEBIAN_FRONTEND=noninteractive apt -y upgrade
-      DEBIAN_FRONTEND=noninteractive apt -y install python3-pip
-
-      # Juju 3.5 is supported until Jan 2025
-      # https://juju.is/docs/juju/roadmap
-      snap install juju --channel=3.5/stable
-      snap install microk8s --channel=1.30-strict/stable
-      snap install --classic charmcraft --channel=3.x/stable
-      snap refresh
-
-      # Install tox from pypi (v4) instead of apt (v3)
-      pip install tox
-
-      # Disable swap
-      sysctl -w vm.swappiness=0
-      echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
-      swapoff -a
-
-      # Disable IPv6
-      echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
-      echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
-      echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
-      sysctl -p
-
-      # Make sure juju directory is present
-      # https://bugs.launchpad.net/juju/+bug/1995697
-      sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
-
-      # setup lxd for charmcraft
-      lxd init --auto
-      adduser ubuntu lxd
-
-      # setup microk8s
-      usermod -a -G snap_microk8s ubuntu
-      usermod -a -G microk8s ubuntu
-      microk8s status --wait-ready
-      microk8s.enable dns
-      microk8s.kubectl rollout status \
-        deployments/coredns \
-        -n kube-system -w --timeout=1800s
-      # Give microk8s another minute to stabilize
-      # to avoid intermittent failures when
-      # enabling hostpath-storage
-      sleep 60
-      microk8s.enable hostpath-storage
-      microk8s.kubectl rollout status \
-        deployments/hostpath-provisioner \
-        -n kube-system -w --timeout=1800s
-
-      # bootstrap microk8s controller and add model
-      sudo -u ubuntu juju bootstrap microk8s microk8s
-      sudo -u ubuntu juju add-model \
-        --config logging-config="<root>=WARNING; unit=DEBUG" \
-        --config update-status-hook-interval="1m" \
-        welcome-k8s
+  REPLACE_PROVISION_DATA
 test_data:
   test_cmds: |
 
@@ -76,10 +9,8 @@ test_data:
     set -e
 
     # Clone repo from appropriate branch/commit.
-    # This is done here rather than in user_data to avoid
-    # race conditions were the test_cmds section runs
-    # before the runcmd section has run on the initial boot.
     ssh ubuntu@$DEVICE_IP '
+      DEBIAN_FRONTEND=noninteractive apt -y install git
       git clone -b REPLACE_BRANCH \
         https://github.com/canonical/intel-device-plugins-k8s-operator.git \
         ~ubuntu/intel-device-plugins-k8s-operator
@@ -89,16 +20,19 @@ test_data:
       git log --name-status HEAD^..HEAD
     '
 
+    # Provision charm environment
+    ssh ubuntu@$DEVICE_IP '
+      sudo ~ubuntu/intel-device-plugins-k8s-operator/.github/testflinger/provision.sh
+    '
+
     # Test 1: Verify that microk8s is installed
     ssh ubuntu@$DEVICE_IP '
-      ~ubuntu/intel-device-plugins-k8s-operator/.github/testflinger/test-cmd-with-timeout.sh \
-        command -v microk8s
+      command -v microk8s
     '
 
     # Test 2: Verify that juju is installed
     ssh ubuntu@$DEVICE_IP '
-      ~ubuntu/intel-device-plugins-k8s-operator/.github/testflinger/test-cmd-with-timeout.sh \
-        command -v juju
+      command -v juju
     '
 
     # Test 3: Verify that juju microk8s model is deployed

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -21,7 +21,7 @@ provision_data:
       # https://juju.is/docs/juju/roadmap
       snap install juju --channel=3.5/stable
       snap install microk8s --channel=1.30-strict/stable
-      snap install --classic charmcraft
+      snap install --classic charmcraft --channel=3.x/stable
       snap refresh
 
       # Install tox from pypi (v4) instead of apt (v3)

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -10,7 +10,7 @@ test_data:
 
     # Clone repo from appropriate branch/commit.
     ssh ubuntu@$DEVICE_IP '
-      DEBIAN_FRONTEND=noninteractive apt -y install git
+      DEBIAN_FRONTEND=noninteractive sudo apt -y install git
       git clone -b REPLACE_BRANCH \
         https://github.com/canonical/intel-device-plugins-k8s-operator.git \
         ~ubuntu/intel-device-plugins-k8s-operator

--- a/.github/testflinger/provision.sh
+++ b/.github/testflinger/provision.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Provision device for charms with microk8s
+#
+# Note, much of this is borrowed from the
+# charm-dev multipass template:
+# https://github.com/canonical/multipass-blueprints/blob/main/v1/charm-dev.yaml
+
+# Install apt and snap packages here instead
+# of in "packages" and "snap" sections
+# to ensure everything runs sequentially
+DEBIAN_FRONTEND=noninteractive apt update
+DEBIAN_FRONTEND=noninteractive apt -y upgrade
+DEBIAN_FRONTEND=noninteractive apt -y install python3-pip
+
+# Juju 3.5 is supported until Jan 2025
+# https://juju.is/docs/juju/roadmap
+snap install juju --channel=3.5/stable
+snap install microk8s --channel=1.30-strict/stable
+snap install --classic charmcraft --channel=3.x/stable
+snap install lxd --channel=5.21/stable
+snap refresh
+
+# Install tox from pypi (v4) instead of apt (v3)
+pip install tox
+
+# Disable swap
+sysctl -w vm.swappiness=0
+echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
+swapoff -a
+
+# Disable IPv6
+echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
+echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
+sysctl -p
+
+# Make sure juju directory is present
+# https://bugs.launchpad.net/juju/+bug/1995697
+sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
+
+# setup lxd for charmcraft
+lxd init --auto
+adduser ubuntu lxd
+
+# setup microk8s
+usermod -a -G snap_microk8s ubuntu
+usermod -a -G microk8s ubuntu
+microk8s status --wait-ready
+microk8s.enable dns
+microk8s.kubectl rollout status \
+  deployments/coredns \
+  -n kube-system -w --timeout=1800s
+# Give microk8s another minute to stabilize
+# to avoid intermittent failures when
+# enabling hostpath-storage
+sleep 60
+microk8s.enable hostpath-storage
+  microk8s.kubectl rollout status \
+  deployments/hostpath-provisioner \
+  -n kube-system -w --timeout=1800s
+
+# bootstrap microk8s controller and add model
+sudo -u ubuntu juju bootstrap microk8s microk8s
+sudo -u ubuntu juju add-model \
+  --config logging-config="<root>=WARNING; unit=DEBUG" \
+  --config update-status-hook-interval="1m" \
+  welcome-k8s

--- a/.github/testflinger/test-cmd-with-timeout.sh
+++ b/.github/testflinger/test-cmd-with-timeout.sh
@@ -22,13 +22,6 @@ cmd="$*"
 while ! ${cmd}; do
   echo "Command '${cmd}' failed, retrying in ${SLEEP_SECS} seconds."
   echo "Elapsed seconds: ${elapsed_secs}"
-  ##
-  # Helpful for tracking the status of cloud-init provisioning
-  ##
-  echo "[DEBUG] Last 50 lines of cloud-init-output.log:"
-  tail -n 50 /var/log/cloud-init-output.log
-  echo "[DEBUG] End of cloud-init-output.log."
-  ##
   sleep ${SLEEP_SECS}
   elapsed_secs=$((elapsed_secs+SLEEP_SECS))
   if (( elapsed_secs > TIMEOUT_SECS )); then

--- a/.github/workflows/unit-and-integration-tests.yaml
+++ b/.github/workflows/unit-and-integration-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       - call-inclusive-naming-check
 
   integration-tests-system-A:
-    name: Integration tests on Testflinger instance with Intel GPU
+    name: Integration tests A on Testflinger instance with Intel GPU(s)
     runs-on: [testflinger]
     steps:
       - name: Check out code
@@ -32,15 +32,14 @@ jobs:
       - name: Build job file from template
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
-          QUEUE: dell-precision-3470-c30322
+          QUEUE: dell-precision-3470-c30322 #ADL iGPU + NVIDIA GPU
           PROVISION_DATA: "distro: jammy"
         run: |
-          sed -i \ 
-            -e "s|REPLACE_BRANCH|${BRANCH}|" \
-            -e "s|REPLACE_QUEUE|${QUEUE}|" \
-            -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
-            ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
-            ${GITHUB_WORKSPACE}/maas2.yaml
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/maas2.yaml
       - name: Submit testflinger job
         uses: canonical/testflinger/.github/actions/submit@main
         with:
@@ -48,7 +47,7 @@ jobs:
           job-path: ${GITHUB_WORKSPACE}/maas2.yaml
 
   integration-tests-system-B:
-    name: Integration tests B on Testflinger instance with Intel GPU
+    name: Integration tests B on Testflinger instance with Intel GPU(s)
     runs-on: [testflinger]
     steps:
       - name: Check out code
@@ -56,15 +55,14 @@ jobs:
       - name: Build job file from template
         env:
           BRANCH: ${{ github.head_ref || github.ref_name }}
-          QUEUE: dell-precision-5680-c31665
+          QUEUE: dell-precision-5680-c31665 #RPL iGPU + Arc Pro A60M dGPU
           PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
         run: |
-          sed -i \ 
-            -e "s|REPLACE_BRANCH|${BRANCH}|" \
-            -e "s|REPLACE_QUEUE|${QUEUE}|" \
-            -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
-            ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
-            ${GITHUB_WORKSPACE}/oemscript.yaml
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/oemscript.yaml
       - name: Submit testflinger job
         uses: canonical/testflinger/.github/actions/submit@main
         with:

--- a/.github/workflows/unit-and-integration-tests.yaml
+++ b/.github/workflows/unit-and-integration-tests.yaml
@@ -23,18 +23,50 @@ jobs:
     needs:
       - call-inclusive-naming-check
 
-  integration-tests:
+  integration-tests-system-A:
     name: Integration tests on Testflinger instance with Intel GPU
-    runs-on: [self-hosted, testflinger]
+    runs-on: [testflinger]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Substitute appropriate branch name in job definition file
+      - name: Build job file from template
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          QUEUE: dell-precision-3470-c30322
+          PROVISION_DATA: "distro: jammy"
         run: |
-          sed -i "s:REPLACE_BRANCH:${{ github.head_ref || github.ref_name }}:" \
-          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml
+          sed -i \ 
+            -e "s|REPLACE_BRANCH|${BRANCH}|" \
+            -e "s|REPLACE_QUEUE|${QUEUE}|" \
+            -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+            ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+            ${GITHUB_WORKSPACE}/maas2.yaml
       - name: Submit testflinger job
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
-          job-path: ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml
+          job-path: ${GITHUB_WORKSPACE}/maas2.yaml
+
+  integration-tests-system-B:
+    name: Integration tests B on Testflinger instance with Intel GPU
+    runs-on: [testflinger]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build job file from template
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          QUEUE: dell-precision-5680-c31665
+          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
+        run: |
+          sed -i \ 
+            -e "s|REPLACE_BRANCH|${BRANCH}|" \
+            -e "s|REPLACE_QUEUE|${QUEUE}|" \
+            -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+            ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+            ${GITHUB_WORKSPACE}/oemscript.yaml
+      - name: Submit testflinger job
+        uses: canonical/testflinger/.github/actions/submit@main
+        with:
+          poll: true
+          job-path: ${GITHUB_WORKSPACE}/oemscript.yaml

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,6 +28,11 @@ bases:
       architectures: ["amd64"]
 parts:
   charm:
+    plugin: charm
+    source: .
+  upstream:
+    plugin: dump
+    source: .
     prime:
       - upstream/**
 config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,7 @@
 #
 # Learn more at: https://juju.is/docs/sdk
 
-"""Dispatch logic for the intel-device-plugins-k8s-operator charm."""
+"""Dispatch logic for the intel-device-plugins-k8s charm."""
 
 import logging
 
@@ -20,7 +20,7 @@ from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 log = logging.getLogger()
 
 
-class IntelDevicePluginsK8SOperatorCharm(CharmBase):
+class IntelDevicePluginsK8sCharm(CharmBase):
     """Charm the service."""
 
     stored = StoredState()
@@ -125,4 +125,4 @@ class IntelDevicePluginsK8SOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(IntelDevicePluginsK8SOperatorCharm)  # type: ignore
+    main(IntelDevicePluginsK8sCharm)  # type: ignore

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest_asyncio
+from lightkube import AsyncClient, KubeConfig
+
+
+@pytest_asyncio.fixture(scope="module")
+async def kubernetes(request):
+    config = KubeConfig.from_file("/var/snap/microk8s/current/credentials/client.config")
+    client = AsyncClient(config=config)
+    yield client

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -63,8 +63,13 @@ async def test_node_label(kubernetes: AsyncClient):
 async def test_node_status(kubernetes: AsyncClient):
     """Verify that the number of GPU slots are the expected value."""
     async for node in kubernetes.list(Node):
-        assert node.status.capacity["gpu.intel.com/i915"] == "10"
-        assert node.status.allocatable["gpu.intel.com/i915"] == "10"
+        # The plugin is configured to allow up to 10 containers
+        # access to each GPU
+        slots_per_gpu = 10
+        gpu_count = int(node.metadata.labels["gpu.intel.com/device-id.0300-a7a0.count"])
+        slots = gpu_count * slots_per_gpu
+        assert node.status.capacity["gpu.intel.com/i915"] == str(slots)
+        assert node.status.allocatable["gpu.intel.com/i915"] == str(slots)
 
 
 async def test_adjust_version(ops_test: OpsTest):

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -66,7 +66,13 @@ async def test_node_status(kubernetes: AsyncClient):
         # The plugin is configured to allow up to 10 containers
         # access to each GPU
         slots_per_gpu = 10
-        gpu_count = int(node.metadata.labels["gpu.intel.com/device-id.0300-a7a0.count"])
+        gpu_count = sum(
+            [
+                int(val)
+                for key, val in node.metadata.labels.items()
+                if key.startswith("gpu.intel.com/device-id.") and key.endswith(".count")
+            ]
+        )
         slots = gpu_count * slots_per_gpu
         assert node.status.capacity["gpu.intel.com/i915"] == str(slots)
         assert node.status.allocatable["gpu.intel.com/i915"] == str(slots)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -29,6 +29,6 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(charm, application_name=APP_NAME, trust=True),
         ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
+            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1800
         ),
     )

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,9 +8,9 @@ from pathlib import Path
 
 import pytest
 import yaml
-from pytest_operator.plugin import OpsTest
-from lightkube import Client
+from lightkube import AsyncClient
 from lightkube.resources.core_v1 import Node
+from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
 
@@ -35,7 +35,23 @@ async def test_build_and_deploy(ops_test: OpsTest):
         ),
     )
 
-async def test_node_label(kubernetes: Client):
+
+async def test_charm_status(ops_test: OpsTest):
+    application = ops_test.model.applications[APP_NAME]
+    units = application.units
+    cert_manager_latest_version = Path("upstream", "cert-manager", "version").read_text().strip()
+    operator_latest_version = (
+        Path("upstream", "intel-device-plugins-operator", "version").read_text().strip()
+    )
+    assert units[0].workload_status == "active"
+    assert units[0].workload_status_message == "Ready"
+    assert application.status == "active"
+    assert (
+        application.workload_version == f"{cert_manager_latest_version},{operator_latest_version}"
+    )
+
+
+async def test_node_label(kubernetes: AsyncClient):
     """Verify that expected node label is present.
 
     This will fail if an Intel GPU is not present on the system.
@@ -43,8 +59,23 @@ async def test_node_label(kubernetes: Client):
     async for node in kubernetes.list(Node):
         assert node.metadata.labels["intel.feature.node.kubernetes.io/gpu"] == "true"
 
-async def test_node_status(kubernetes: Client):
+
+async def test_node_status(kubernetes: AsyncClient):
     """Verify that the number of GPU slots are the expected value."""
     async for node in kubernetes.list(Node):
         assert node.status.capacity["gpu.intel.com/i915"] == "10"
         assert node.status.allocatable["gpu.intel.com/i915"] == "10"
+
+
+async def test_adjust_version(ops_test: OpsTest):
+    """Verify that the application versions can be adjusted."""
+    update_status_timeout = 1800
+    application = ops_test.model.applications[APP_NAME]
+    await application.set_config({"intel-device-plugins-operator-release": "0.29.0"})
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)
+    await application.reset_config(["intel-device-plugins-operator-release"])
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)
+    await application.set_config({"cert-manager-release": "v1.14.5"})
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)
+    await application.reset_config(["cert-manager-release"])
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,14 +4,14 @@
 import unittest.mock as mock
 
 import pytest
-from charm import IntelDevicePluginsK8SOperatorCharm
+from charm import IntelDevicePluginsK8sCharm
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
 
 @pytest.fixture
 def harness():
-    harness = Harness(IntelDevicePluginsK8SOperatorCharm)
+    harness = Harness(IntelDevicePluginsK8sCharm)
     try:
         harness.set_leader(is_leader=True)
         yield harness

--- a/tests/unit/test_manifests_operator.py
+++ b/tests/unit/test_manifests_operator.py
@@ -23,8 +23,8 @@ def harness():
 def test_patch_plugin_name(harness: Harness):
     patch = PatchPluginName(harness.charm.collector.manifests)
     obj = mock.MagicMock()
-    d = {"kind": "GpuDevicePlugin", "metadata": {"name": "dummydeviceplugin-sample"}}
+    d = {"kind": "GpuDevicePlugin", "metadata": {"name": "mockdeviceplugin-sample"}}
     obj.__getitem__.side_effect = d.__getitem__
     obj.kind = d["kind"]
     patch(obj)
-    assert obj["metadata"]["name"] == "dummydeviceplugin"
+    assert obj["metadata"]["name"] == "mockdeviceplugin"

--- a/tests/unit/test_manifests_operator.py
+++ b/tests/unit/test_manifests_operator.py
@@ -4,14 +4,14 @@
 import unittest.mock as mock
 
 import pytest
-from charm import IntelDevicePluginsK8SOperatorCharm
+from charm import IntelDevicePluginsK8sCharm
 from manifests_operator import PatchPluginName
 from ops.testing import Harness
 
 
 @pytest.fixture
 def harness():
-    harness = Harness(IntelDevicePluginsK8SOperatorCharm)
+    harness = Harness(IntelDevicePluginsK8sCharm)
     try:
         harness.begin()
         harness.set_leader(is_leader=True)

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     ruff
 commands =
     black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards


### PR DESCRIPTION
This adds more test cases to the integration tests running on a testflinger instance. Previously, the only integration test was checking whether the charm would build and could be successfully deployed. The following tests included in this PR are designed to test the following:

* Node labels from the GPU plugin are present and correct
* The number of allocated container slots on the node is correct
* The application is in the correct state and has the expected version information
* The version of the operator and cert-manager components can be adjusted and the operator comes back up (this case is less useful now because there is only one version of each)

I also included some other minor cleanup to improve the stability and reproducibility of the test setup, and cleaned up some of the naming.