### PR TITLE
Improve integration test coverage, clean up naming

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -28,6 +28,11 @@ bases:
       architectures: ["amd64"]
 parts:
   charm:
+    plugin: charm
+    source: .
+  upstream:
+    plugin: dump
+    source: .
     prime:
       - upstream/**
 config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -4,7 +4,7 @@
 #
 # Learn more at: https://juju.is/docs/sdk
 
-"""Dispatch logic for the intel-device-plugins-k8s-operator charm."""
+"""Dispatch logic for the intel-device-plugins-k8s charm."""
 
 import logging
 
@@ -20,7 +20,7 @@ from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 log = logging.getLogger()
 
 
-class IntelDevicePluginsK8SOperatorCharm(CharmBase):
+class IntelDevicePluginsK8sCharm(CharmBase):
     """Charm the service."""
 
     stored = StoredState()
@@ -125,4 +125,4 @@ class IntelDevicePluginsK8SOperatorCharm(CharmBase):
 
 
 if __name__ == "__main__":  # pragma: nocover
-    main(IntelDevicePluginsK8SOperatorCharm)  # type: ignore
+    main(IntelDevicePluginsK8sCharm)  # type: ignore

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,12 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest_asyncio
+from lightkube import AsyncClient, KubeConfig
+
+
+@pytest_asyncio.fixture(scope="module")
+async def kubernetes(request):
+    config = KubeConfig.from_file("/var/snap/microk8s/current/credentials/client.config")
+    client = AsyncClient(config=config)
+    yield client

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,6 +8,8 @@ from pathlib import Path
 
 import pytest
 import yaml
+from lightkube import AsyncClient
+from lightkube.resources.core_v1 import Node
 from pytest_operator.plugin import OpsTest
 
 logger = logging.getLogger(__name__)
@@ -29,6 +31,62 @@ async def test_build_and_deploy(ops_test: OpsTest):
     await asyncio.gather(
         ops_test.model.deploy(charm, application_name=APP_NAME, trust=True),
         ops_test.model.wait_for_idle(
-            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1000
+            apps=[APP_NAME], status="active", raise_on_blocked=True, timeout=1800
         ),
     )
+
+
+async def test_charm_status(ops_test: OpsTest):
+    application = ops_test.model.applications[APP_NAME]
+    units = application.units
+    cert_manager_latest_version = Path("upstream", "cert-manager", "version").read_text().strip()
+    operator_latest_version = (
+        Path("upstream", "intel-device-plugins-operator", "version").read_text().strip()
+    )
+    assert units[0].workload_status == "active"
+    assert units[0].workload_status_message == "Ready"
+    assert application.status == "active"
+    assert (
+        application.workload_version == f"{cert_manager_latest_version},{operator_latest_version}"
+    )
+
+
+async def test_node_label(kubernetes: AsyncClient):
+    """Verify that expected node label is present.
+
+    This will fail if an Intel GPU is not present on the system.
+    """
+    async for node in kubernetes.list(Node):
+        assert node.metadata.labels["intel.feature.node.kubernetes.io/gpu"] == "true"
+
+
+async def test_node_status(kubernetes: AsyncClient):
+    """Verify that the number of GPU slots are the expected value."""
+    async for node in kubernetes.list(Node):
+        # The plugin is configured to allow up to 10 containers
+        # access to each GPU
+        slots_per_gpu = 10
+        gpu_count = sum(
+            [
+                int(val)
+                for key, val in node.metadata.labels.items()
+                if key.startswith("gpu.intel.com/device-id.") and key.endswith(".count")
+            ]
+        )
+        slots = gpu_count * slots_per_gpu
+        assert node.status.capacity["gpu.intel.com/i915"] == str(slots)
+        assert node.status.allocatable["gpu.intel.com/i915"] == str(slots)
+
+
+async def test_adjust_version(ops_test: OpsTest):
+    """Verify that the application versions can be adjusted."""
+    update_status_timeout = 1800
+    application = ops_test.model.applications[APP_NAME]
+    await application.set_config({"intel-device-plugins-operator-release": "0.29.0"})
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)
+    await application.reset_config(["intel-device-plugins-operator-release"])
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)
+    await application.set_config({"cert-manager-release": "v1.14.5"})
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)
+    await application.reset_config(["cert-manager-release"])
+    await ops_test.model.wait_for_idle(status="active", timeout=update_status_timeout)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,14 +4,14 @@
 import unittest.mock as mock
 
 import pytest
-from charm import IntelDevicePluginsK8SOperatorCharm
+from charm import IntelDevicePluginsK8sCharm
 from ops.model import ActiveStatus, MaintenanceStatus, WaitingStatus
 from ops.testing import Harness
 
 
 @pytest.fixture
 def harness():
-    harness = Harness(IntelDevicePluginsK8SOperatorCharm)
+    harness = Harness(IntelDevicePluginsK8sCharm)
     try:
         harness.set_leader(is_leader=True)
         yield harness

--- a/tests/unit/test_manifests_operator.py
+++ b/tests/unit/test_manifests_operator.py
@@ -4,14 +4,14 @@
 import unittest.mock as mock
 
 import pytest
-from charm import IntelDevicePluginsK8SOperatorCharm
+from charm import IntelDevicePluginsK8sCharm
 from manifests_operator import PatchPluginName
 from ops.testing import Harness
 
 
 @pytest.fixture
 def harness():
-    harness = Harness(IntelDevicePluginsK8SOperatorCharm)
+    harness = Harness(IntelDevicePluginsK8sCharm)
     try:
         harness.begin()
         harness.set_leader(is_leader=True)
@@ -23,8 +23,8 @@ def harness():
 def test_patch_plugin_name(harness: Harness):
     patch = PatchPluginName(harness.charm.collector.manifests)
     obj = mock.MagicMock()
-    d = {"kind": "GpuDevicePlugin", "metadata": {"name": "dummydeviceplugin-sample"}}
+    d = {"kind": "GpuDevicePlugin", "metadata": {"name": "mockdeviceplugin-sample"}}
     obj.__getitem__.side_effect = d.__getitem__
     obj.kind = d["kind"]
     patch(obj)
-    assert obj["metadata"]["name"] == "dummydeviceplugin"
+    assert obj["metadata"]["name"] == "mockdeviceplugin"

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ deps =
     ruff
 commands =
     black {[vars]all_path}
-    ruff --fix {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards


### PR DESCRIPTION
Splitting up https://github.com/canonical/intel-device-plugins-k8s-operator/pull/9 into two separate PRs. This is the first which is focused on improving integration test coverage.