### PR TITLE
Add second testflinger system to CI

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -1,73 +1,7 @@
-job_queue: dell-precision-3470-c30322
+job_queue: REPLACE_QUEUE
+output_timeout: 1800
 provision_data:
-  distro: jammy
-  user_data: |
-    #cloud-config
-    # Note, much of this is borrowed from the
-    # charm-dev multipass template:
-    # https://github.com/canonical/multipass-blueprints/blob/main/v1/charm-dev.yaml
-
-    runcmd:
-    - |
-      # Install apt and snap packages here instead
-      # of in "packages" and "snap" sections
-      # to ensure everything runs sequentially
-      DEBIAN_FRONTEND=noninteractive apt update
-      DEBIAN_FRONTEND=noninteractive apt -y upgrade
-      DEBIAN_FRONTEND=noninteractive apt -y install python3-pip
-
-      # Juju 3.5 is supported until Jan 2025
-      # https://juju.is/docs/juju/roadmap
-      snap install juju --channel=3.5/stable
-      snap install microk8s --channel=1.30-strict/stable
-      snap install --classic charmcraft
-      snap refresh
-
-      # Install tox from pypi (v4) instead of apt (v3)
-      pip install tox
-
-      # Disable swap
-      sysctl -w vm.swappiness=0
-      echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
-      swapoff -a
-
-      # Disable IPv6
-      echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
-      echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
-      echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
-      sysctl -p
-
-      # Make sure juju directory is present
-      # https://bugs.launchpad.net/juju/+bug/1995697
-      sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
-
-      # setup lxd for charmcraft
-      lxd init --auto
-      adduser ubuntu lxd
-
-      # setup microk8s
-      usermod -a -G snap_microk8s ubuntu
-      usermod -a -G microk8s ubuntu
-      microk8s status --wait-ready
-      microk8s.enable dns
-      microk8s.kubectl rollout status \
-        deployments/coredns \
-        -n kube-system -w --timeout=1800s
-      # Give microk8s another minute to stabilize
-      # to avoid intermittent failures when
-      # enabling hostpath-storage
-      sleep 60
-      microk8s.enable hostpath-storage
-      microk8s.kubectl rollout status \
-        deployments/hostpath-provisioner \
-        -n kube-system -w --timeout=1800s
-
-      # bootstrap microk8s controller and add model
-      sudo -u ubuntu juju bootstrap microk8s microk8s
-      sudo -u ubuntu juju add-model \
-        --config logging-config="<root>=WARNING; unit=DEBUG" \
-        --config update-status-hook-interval="1m" \
-        welcome-k8s
+  REPLACE_PROVISION_DATA
 test_data:
   test_cmds: |
 
@@ -75,10 +9,8 @@ test_data:
     set -e
 
     # Clone repo from appropriate branch/commit.
-    # This is done here rather than in user_data to avoid
-    # race conditions were the test_cmds section runs
-    # before the runcmd section has run on the initial boot.
     ssh ubuntu@$DEVICE_IP '
+      DEBIAN_FRONTEND=noninteractive sudo apt -y install git
       git clone -b REPLACE_BRANCH \
         https://github.com/canonical/intel-device-plugins-k8s-operator.git \
         ~ubuntu/intel-device-plugins-k8s-operator
@@ -88,16 +20,19 @@ test_data:
       git log --name-status HEAD^..HEAD
     '
 
+    # Provision charm environment
+    ssh ubuntu@$DEVICE_IP '
+      sudo ~ubuntu/intel-device-plugins-k8s-operator/.github/testflinger/provision.sh
+    '
+
     # Test 1: Verify that microk8s is installed
     ssh ubuntu@$DEVICE_IP '
-      ~ubuntu/intel-device-plugins-k8s-operator/.github/testflinger/test-cmd-with-timeout.sh \
-        command -v microk8s
+      command -v microk8s
     '
 
     # Test 2: Verify that juju is installed
     ssh ubuntu@$DEVICE_IP '
-      ~ubuntu/intel-device-plugins-k8s-operator/.github/testflinger/test-cmd-with-timeout.sh \
-        command -v juju
+      command -v juju
     '
 
     # Test 3: Verify that juju microk8s model is deployed

--- a/.github/testflinger/provision.sh
+++ b/.github/testflinger/provision.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+#
+# Provision device for charms with microk8s
+#
+# Note, much of this is borrowed from the
+# charm-dev multipass template:
+# https://github.com/canonical/multipass-blueprints/blob/main/v1/charm-dev.yaml
+
+# Install apt and snap packages here instead
+# of in "packages" and "snap" sections
+# to ensure everything runs sequentially
+DEBIAN_FRONTEND=noninteractive apt update
+DEBIAN_FRONTEND=noninteractive apt -y upgrade
+DEBIAN_FRONTEND=noninteractive apt -y install python3-pip
+
+# Juju 3.5 is supported until Jan 2025
+# https://juju.is/docs/juju/roadmap
+snap install juju --channel=3.5/stable
+snap install microk8s --channel=1.30-strict/stable
+snap install --classic charmcraft --channel=3.x/stable
+snap install lxd --channel=5.21/stable
+snap refresh
+
+# Install tox from pypi (v4) instead of apt (v3)
+pip install tox
+
+# Disable swap
+sysctl -w vm.swappiness=0
+echo "vm.swappiness = 0" | tee -a /etc/sysctl.conf
+swapoff -a
+
+# Disable IPv6
+echo "net.ipv6.conf.all.disable_ipv6=1" | tee -a /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6=1" | tee -a /etc/sysctl.conf
+echo "net.ipv6.conf.lo.disable_ipv6=1" | tee -a /etc/sysctl.conf
+sysctl -p
+
+# Make sure juju directory is present
+# https://bugs.launchpad.net/juju/+bug/1995697
+sudo -u ubuntu mkdir -p /home/ubuntu/.local/share/juju
+
+# setup lxd for charmcraft
+lxd init --auto
+adduser ubuntu lxd
+
+# setup microk8s
+usermod -a -G snap_microk8s ubuntu
+usermod -a -G microk8s ubuntu
+microk8s status --wait-ready
+microk8s.enable dns
+microk8s.kubectl rollout status \
+  deployments/coredns \
+  -n kube-system -w --timeout=1800s
+# Give microk8s another minute to stabilize
+# to avoid intermittent failures when
+# enabling hostpath-storage
+sleep 60
+microk8s.enable hostpath-storage
+  microk8s.kubectl rollout status \
+  deployments/hostpath-provisioner \
+  -n kube-system -w --timeout=1800s
+
+# bootstrap microk8s controller and add model
+sudo -u ubuntu juju bootstrap microk8s microk8s
+sudo -u ubuntu juju add-model \
+  --config logging-config="<root>=WARNING; unit=DEBUG" \
+  --config update-status-hook-interval="1m" \
+  welcome-k8s

--- a/.github/testflinger/test-cmd-with-timeout.sh
+++ b/.github/testflinger/test-cmd-with-timeout.sh
@@ -22,13 +22,6 @@ cmd="$*"
 while ! ${cmd}; do
   echo "Command '${cmd}' failed, retrying in ${SLEEP_SECS} seconds."
   echo "Elapsed seconds: ${elapsed_secs}"
-  ##
-  # Helpful for tracking the status of cloud-init provisioning
-  ##
-  echo "[DEBUG] Last 50 lines of cloud-init-output.log:"
-  tail -n 50 /var/log/cloud-init-output.log
-  echo "[DEBUG] End of cloud-init-output.log."
-  ##
   sleep ${SLEEP_SECS}
   elapsed_secs=$((elapsed_secs+SLEEP_SECS))
   if (( elapsed_secs > TIMEOUT_SECS )); then

--- a/.github/workflows/unit-and-integration-tests.yaml
+++ b/.github/workflows/unit-and-integration-tests.yaml
@@ -23,18 +23,48 @@ jobs:
     needs:
       - call-inclusive-naming-check
 
-  integration-tests:
-    name: Integration tests on Testflinger instance with Intel GPU
-    runs-on: [self-hosted, testflinger]
+  integration-tests-system-A:
+    name: Integration tests A on Testflinger instance with Intel GPU(s)
+    runs-on: [testflinger]
     steps:
       - name: Check out code
         uses: actions/checkout@v4
-      - name: Substitute appropriate branch name in job definition file
+      - name: Build job file from template
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          QUEUE: dell-precision-3470-c30322 #ADL iGPU + NVIDIA GPU
+          PROVISION_DATA: "distro: jammy"
         run: |
-          sed -i "s:REPLACE_BRANCH:${{ github.head_ref || github.ref_name }}:" \
-          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/maas2.yaml
       - name: Submit testflinger job
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
-          job-path: ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml
+          job-path: ${GITHUB_WORKSPACE}/maas2.yaml
+
+  integration-tests-system-B:
+    name: Integration tests B on Testflinger instance with Intel GPU(s)
+    runs-on: [testflinger]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build job file from template
+        env:
+          BRANCH: ${{ github.head_ref || github.ref_name }}
+          QUEUE: dell-precision-5680-c31665 #RPL iGPU + Arc Pro A60M dGPU
+          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-muk/X96_A00/dell-bto-jammy-jellyfish-muk-X96-20230419-19_A00.iso"
+        run: |
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/oemscript.yaml
+      - name: Submit testflinger job
+        uses: canonical/testflinger/.github/actions/submit@main
+        with:
+          poll: true
+          job-path: ${GITHUB_WORKSPACE}/oemscript.yaml


### PR DESCRIPTION
Splitting up https://github.com/canonical/intel-device-plugins-k8s-operator/pull/9 into two separate PRs. The first (https://github.com/canonical/intel-device-plugins-k8s-operator/pull/10) focused on improving integration testing coverage. 

This is the second PR and focuses on adding a second testflinger system to the integration testing. The second system contains a raptor lake CPU with both an Intel iGPU and dGPU, whereas the first system is alder lake with an Intel iGPU and NVIDIA GPU.

Much of the work for this PR is reorganizing the CI to be generic enough to work with both maas2 and oemscript-based Testflinger provisioning methods. Specifically, since [oemscript provisioning does not support a cloud-init user-data key](https://canonical-testflinger.readthedocs-hosted.com/en/latest/reference/device-connector-types/#dell-oemscript), the `user_data` section was removed and replaced with a script that is run at the beginning of the `test_cmd` section.